### PR TITLE
Use keep-a-changelog functions for modifying changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use functions from keep-a-changelog instead the Semver library directly to avoid library versioning issues
+
 ## [0.1.4] - 2018-08-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,9 +1649,9 @@
       "dev": true
     },
     "keep-a-changelog": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-0.6.3.tgz",
-      "integrity": "sha512-BuQyB3x3KMac9E7SRE2KN4VrkO8LuL/BMdL93T+XPYFGkBD5vEiX7xGx+dSR+XFNOXV4ELo/VHZqakFcNf+dLQ==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-0.6.4.tgz",
+      "integrity": "sha512-4/zm9sydI1VkOu1bQ+AZWAbw6Pq3GbacuaZ9u/sMU7evxBqVEJ6BKg1ZvMacQTm6vFujK3Lu2NUgKysPvk0whw==",
       "requires": {
         "gitconfiglocal": "^2.0.2",
         "semver": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^2.4.1",
-    "keep-a-changelog": "^0.6.3",
-    "semver": "^5.5.1"
+    "keep-a-changelog": "^0.6.4"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const Semver = require('semver');
 const { parser, Release, Changelog } = require('keep-a-changelog');
 const fs = require('fs');
 const chalk = require('chalk');
@@ -98,13 +97,13 @@ module.exports.release = function () {
   const changelog = getChangelog();
   changelog.url = pkg.repository.url;
 
-  const unreleased = changelog.releases.find(release => !release.version);
-  const existingRelease = changelog.releases.some(release => release.version && Semver.eq(release.version, pkg.version));
+  const unreleased = changelog.findRelease();
+  const existingRelease = changelog.findRelease(pkg.version);
 
   if (!existingRelease) {
     ensureChangesForRelease(unreleased);
-    
-    unreleased.version = new Semver(pkg.version);
+
+    unreleased.setVersion(pkg.version);
     unreleased.date = new Date();
 
     changelog.addRelease(new Release());


### PR DESCRIPTION
**Changes proposed in this pull request:**

This PR uses the `findRelease` and `setVersion` functions from `keep-a-changelog` to avoid dealing with Semver library version issues.

Resolves #8 

**Checklist**

- [ ] Unit tests added
- [ ] Documentation is up-to-date
- [ ] Changelog is updated